### PR TITLE
ci: surface deps and refactor in changelog, hide dev-dep bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       day: "sunday"
       timezone: "America/Los_Angeles"
     commit-message:
-      prefix: "deps"
+      prefix: "deps(dev)"
   - package-ecosystem: "npm"
     directory: "/"
     open-pull-requests-limit: 5
@@ -20,6 +20,7 @@ updates:
       timezone: "America/Los_Angeles"
     commit-message:
       prefix: "deps"
+      prefix-development: "deps(dev)"
     groups:
       dev-patch-minor-dependencies:
         dependency-type: "development"

--- a/.github/release-configs/release-please-config.beta.json
+++ b/.github/release-configs/release-please-config.beta.json
@@ -8,7 +8,22 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "prerelease": true,
-      "prerelease-type": "beta"
+      "prerelease-type": "beta",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "deps", "scope": "dev", "section": "Dependencies", "hidden": true },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",

--- a/.github/release-configs/release-please-config.json
+++ b/.github/release-configs/release-please-config.json
@@ -6,7 +6,22 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["README.md"],
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "deps", "scope": "dev", "section": "Dependencies", "hidden": true },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
## Summary

Today `deps:` commits are dropped from the CHANGELOG and don't trigger releases — `conventional-changelog-conventionalcommits`'s `DEFAULT_COMMIT_TYPES` doesn't include `deps`, the writer's `transform` discards unmatched non-breaking commits, and release-please's `changelogEmpty` check then skips the release PR. That's why six dependabot bumps piled up between v0.2.0 and v0.3.0 with nothing landing until the unrelated `feat!:` shipped.

This PR adds explicit `changelog-sections` to both release-please configs so:
- `deps:` (production deps) → **Dependencies** section, triggers a patch release.
- `deps(dev):` (dev deps) → hidden, no changelog entry, no release.
- `refactor:` → **Code Refactoring** section (was hidden by the upstream default).

It also updates `.github/dependabot.yml`:
- npm ecosystem: add `prefix-development: "deps(dev)"` so dev-dependency bumps use the new prefix.
- github-actions ecosystem: switch to `prefix: "deps(dev)"` so workflow-action bumps don't drive releases.

> [!NOTE]
> This duplicates a change being submitted upstream to `heroku/npm-release-workflows` (PR adds the same defaults to `base-config.yml`). Once that lands and `update-release-configs.yml` runs, the generator will regenerate these JSON files with equivalent content — no follow-up action required.
>
> Going forward, manual dependency bumps should use `deps(dev):` for devDependencies and `deps:` for production. Dependabot is configured to do the right thing automatically.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
This change only affects release tooling, not production code. Validation is done by exercising the release workflow in dry-run mode and observing the next dependabot PRs.

**Steps**:
1. Manually trigger the Release workflow (`workflow_dispatch`) with `dry_run: true`. Confirm a release PR is opened and that recent `deps:` commits show up under **Dependencies** in the proposed CHANGELOG, while `test:` and `chore:` commits stay out.
2. After the next scheduled dependabot run, verify production-dependency bumps produce `deps:` commits and devDependency bumps produce `deps(dev):` commits.
3. Verify a `deps(dev):`-only commit range does **not** open a release PR.

## Screenshots (if applicable)

## Related Issues
GitHub issue: N/A
GUS work item: N/A