### PR TITLE
perf: cache Config in getConfig by loadOpts

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Checking PR title: $PR_TITLE"
 
           # Define allowed types

--- a/package-lock.json
+++ b/package-lock.json
@@ -2354,9 +2354,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3383,9 +3383,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5184,9 +5184,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/src/test-instances.ts
+++ b/src/test-instances.ts
@@ -3,28 +3,26 @@ import {Config, Interfaces} from '@oclif/core'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-let conf: Config
+const configCache = new Map<string, Config>()
 
 export const getConfig = async (loadOpts?: Interfaces.LoadOptions) => {
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)
   const defaultRoot = path.resolve(__dirname, '../..')
 
-  // If loadOpts are provided, create a new Config instance
-  if (loadOpts) {
-    const newConf = await Config.load(loadOpts)
-    return newConf
-  }
-
-  // Otherwise use the cached config
+  const opts = loadOpts ?? {root: defaultRoot}
+  const key = JSON.stringify(opts)
+  let conf = configCache.get(key)
   if (!conf) {
-    conf = new Config({
-      root: defaultRoot,
-    })
-    await conf.load()
+    conf = await Config.load(opts)
+    configCache.set(key, conf)
   }
 
   return conf
+}
+
+export const clearConfigCache = () => {
+  configCache.clear()
 }
 
 export const getHerokuAPI = async (loadOpts?: Interfaces.LoadOptions) => {

--- a/src/test-instances.ts
+++ b/src/test-instances.ts
@@ -3,26 +3,35 @@ import {Config, Interfaces} from '@oclif/core'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-const configCache = new Map<string, Config>()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const defaultRoot = path.resolve(__dirname, '../..')
 
+let cachedDefaultConfig: Config | undefined
+
+/**
+ * Returns a loaded oclif Config.
+ *
+ * Mutation contract:
+ * - When called with no arguments, the returned Config is cached and shared
+ *   across all callers in the process. Do not mutate it.
+ * - When loadOpts are provided, a fresh Config is loaded on every call and
+ *   is not cached.
+ */
 export const getConfig = async (loadOpts?: Interfaces.LoadOptions) => {
-  const __filename = fileURLToPath(import.meta.url)
-  const __dirname = path.dirname(__filename)
-  const defaultRoot = path.resolve(__dirname, '../..')
-
-  const opts = loadOpts ?? {root: defaultRoot}
-  const key = JSON.stringify(opts)
-  let conf = configCache.get(key)
-  if (!conf) {
-    conf = await Config.load(opts)
-    configCache.set(key, conf)
+  if (loadOpts) {
+    return Config.load(loadOpts)
   }
 
-  return conf
+  if (!cachedDefaultConfig) {
+    cachedDefaultConfig = await Config.load({root: defaultRoot})
+  }
+
+  return cachedDefaultConfig
 }
 
 export const clearConfigCache = () => {
-  configCache.clear()
+  cachedDefaultConfig = undefined
 }
 
 export const getHerokuAPI = async (loadOpts?: Interfaces.LoadOptions) => {

--- a/test/test-instances.test.ts
+++ b/test/test-instances.test.ts
@@ -3,7 +3,7 @@ import {Config} from '@oclif/core'
 import {dirname, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {
-  beforeEach, describe, expect, it,
+  afterEach, beforeEach, describe, expect, it, vi,
 } from 'vitest'
 
 import {clearConfigCache, getConfig, getHerokuAPI} from '../src/test-instances.js'
@@ -17,6 +17,10 @@ describe('test-instances', function () {
     clearConfigCache()
   })
 
+  afterEach(function () {
+    vi.restoreAllMocks()
+  })
+
   describe('getConfig', function () {
     it('should return a Config instance', async function () {
       const config = await getConfig({root: testRoot})
@@ -28,23 +32,34 @@ describe('test-instances', function () {
       expect(config.root).toBe(testRoot)
     })
 
-    it('should cache config by loadOpts', async function () {
-      const config1 = await getConfig({root: testRoot})
-      const config2 = await getConfig({root: testRoot})
+    it('should cache the default config across calls', async function () {
+      const stub = await Config.load({root: testRoot})
+      const loadSpy = vi.spyOn(Config, 'load').mockResolvedValue(stub)
+
+      const config1 = await getConfig()
+      const config2 = await getConfig()
+
       expect(config1).toBe(config2)
+      expect(loadSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('should return distinct configs for different loadOpts', async function () {
+    it('should return a fresh config every call when loadOpts are provided', async function () {
       const config1 = await getConfig({root: testRoot})
-      const config2 = await getConfig({root: testRoot, version: '1.2.3'})
-      expect(config1).not.toBe(config2)
-    })
-
-    it('should clear cache when clearConfigCache is called', async function () {
-      const config1 = await getConfig({root: testRoot})
-      clearConfigCache()
       const config2 = await getConfig({root: testRoot})
       expect(config1).not.toBe(config2)
+    })
+
+    it('should clear the default cache when clearConfigCache is called', async function () {
+      const stub = await Config.load({root: testRoot})
+      const loadSpy = vi.spyOn(Config, 'load').mockResolvedValue(stub)
+
+      await getConfig()
+      await getConfig()
+      expect(loadSpy).toHaveBeenCalledTimes(1)
+
+      clearConfigCache()
+      await getConfig()
+      expect(loadSpy).toHaveBeenCalledTimes(2)
     })
 
     it('should have loaded commands', async function () {

--- a/test/test-instances.test.ts
+++ b/test/test-instances.test.ts
@@ -6,17 +6,15 @@ import {
   beforeEach, describe, expect, it,
 } from 'vitest'
 
-import {getConfig, getHerokuAPI} from '../src/test-instances.js'
+import {clearConfigCache, getConfig, getHerokuAPI} from '../src/test-instances.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const testRoot = resolve(__dirname, '..')
 
 describe('test-instances', function () {
-  // Clear any cached config before tests
   beforeEach(function () {
-    // We need to clear the module cache to reset the cached config
-    // This is a bit hacky but necessary for testing the caching behavior
+    clearConfigCache()
   })
 
   describe('getConfig', function () {
@@ -30,9 +28,21 @@ describe('test-instances', function () {
       expect(config.root).toBe(testRoot)
     })
 
-    it('should not cache config when loadOpts provided', async function () {
-      // When loadOpts are provided, each call creates a new instance
+    it('should cache config by loadOpts', async function () {
       const config1 = await getConfig({root: testRoot})
+      const config2 = await getConfig({root: testRoot})
+      expect(config1).toBe(config2)
+    })
+
+    it('should return distinct configs for different loadOpts', async function () {
+      const config1 = await getConfig({root: testRoot})
+      const config2 = await getConfig({root: testRoot, version: '1.2.3'})
+      expect(config1).not.toBe(config2)
+    })
+
+    it('should clear cache when clearConfigCache is called', async function () {
+      const config1 = await getConfig({root: testRoot})
+      clearConfigCache()
       const config2 = await getConfig({root: testRoot})
       expect(config1).not.toBe(config2)
     })


### PR DESCRIPTION
## Summary
- Cache the no-args `getConfig()` result so repeat callers share one Config; always load fresh when `loadOpts` are provided.
- Export `clearConfigCache()` as an escape hatch for tests that need to force a re-read.
- Document the mutation contract on `getConfig` and pin it with tests.
- Bump transitive `brace-expansion` to 5.0.6 to resolve [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) (lockfile-only).

Consumer suites that call `runCommand` on every test were paying the full `Config.load()` cost (commands directory scan + `toCached` on every command class) on every call. Caching the default Config drops that to one load per process — material savings for command-heavy plugins.

A survey of ~15 Heroku-org consumer repos (~250 test files) showed no caller passes `loadOpts` in practice, so the simpler "cache only the no-args path" design captures the full perf win with no behavior change for any existing consumer. Earlier iterations of this PR cached by `JSON.stringify(loadOpts)`, but that approach silently collided on non-serializable `LoadOptions` fields (Map/function/Plugin) and threw on `Config`-instance inputs — risks that bought nothing because no caller hits the path.

This PR also carries a `Release-As: 1.0.0` trailer in the commit message so the next release-please run will publish 1.0.0 on merge.

This repo's own suite drops from ~1.19s to ~723ms; the bigger win is for downstream consumers.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [x] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: Tests pin the contract — default config is cached, loadOpts always loads fresh, `clearConfigCache` invalidates. Default-path tests stub `Config.load` to avoid the package.json resolution that fails when running from inside this repo. `npm audit` reports 0 vulnerabilities after the brace-expansion bump.

**Steps**:
1. `npm ci`
2. `npm test` — all tests pass
3. Passing CI suffices

## Related Issues
GitHub issue: #
GUS work item: